### PR TITLE
Quote path of file to be opened so that directories can have spaces.

### DIFF
--- a/lib/xray-rails.rb
+++ b/lib/xray-rails.rb
@@ -66,7 +66,7 @@ module Xray
 
   # Returns augmented HTML where the source is simply wrapped in an HTML
   # comment with filepath info. Xray.js uses these comments to associate
-  # elements with the tempaltes that rendered them.
+  # elements with the templates that rendered them.
   #
   # This:
   #   <div class=".my-element">

--- a/spec/xray/command_spec.rb
+++ b/spec/xray/command_spec.rb
@@ -5,7 +5,7 @@ describe 'Xray.open_file' do
 
   it "uses the configured editor" do
     Xray.config.stub(editor: 'cool_editor')
-    Open3.should_receive(:capture3).with("cool_editor #{file}")
+    Open3.should_receive(:capture3).with("cool_editor \"#{file}\"")
     Xray.open_file(file)
   end
 


### PR DESCRIPTION
My machine has a space in the name of the drive and the files were having trouble opening in the editor. Quoting the path of the file fixes the issue and shouldn't cause any issues with other paths.
