### PR TITLE
Check that the response is not empty before calling html_request? in should_inject_xray

### DIFF
--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -68,9 +68,9 @@ module Xray
 
     def should_inject_xray?(status, headers, response)
       status == 200 &&
+      !empty?(response) &&
       html_request?(headers, response) &&
       !file?(headers) &&
-      !empty?(response) &&
       !response.body.frozen?
     end
 


### PR DESCRIPTION
`html_request?(headers, response)` will fail to run (crash on `response.body.include?("<html")`) when called on a response that is an array or doesn't have a body for any reason.

I moved the check for response emptiness to run before html_request?

Maybe `empty?` should be called in the `html_request?` method itself?
