### PR TITLE
Improve error message when the asset pipeline is disabled

### DIFF
--- a/lib/xray/engine.rb
+++ b/lib/xray/engine.rb
@@ -7,6 +7,7 @@ module Xray
   # xray.js and the xray bar into the app's response bodies.
   class Engine < ::Rails::Engine
     initializer "xray.initialize" do |app|
+      ensure_asset_pipeline_enabled! app
       app.middleware.use Xray::Middleware
 
       # Register as a Sprockets processor to augment JS files, including
@@ -82,6 +83,14 @@ module Xray
             :layout => layout
           }
         end
+      end
+    end
+
+    def ensure_asset_pipeline_enabled!(app)
+      unless app.assets
+        raise "xray-rails requires the Rails asset pipeline.
+The asset pipeline is currently disabled in this application.
+Either convert your application to use the asset pipeline, or remove xrail-rails from your Gemfile."
       end
     end
   end


### PR DESCRIPTION
If you attempt to use xray-rails with an application that doesn't use the Rails asset pipeline (config.assets.enabled = false), you get an unhelpful error message:

```
/Users/jflanagan/code/xray-rails/lib/xray/engine.rb:15:in `block in <class:Engine>': undefined method `register_postprocessor' for nil:NilClass (NoMethodError)
    from /Users/jflanagan/.rvm/gems/ruby-1.9.3-p327-fast@pa/gems/railties-3.2.11/lib/rails/initializable.rb:30:in `instance_exec'
```

This PR attempts to provide a better experience:

```
/Users/jflanagan/code/xray-rails/lib/xray/engine.rb:93:in `ensure_asset_pipeline_enabled!': xray-rails requires the Rails asset pipeline. (RuntimeError)
The asset pipeline is currently disabled in this application.
Either convert your application to use the asset pipeline, or remove xrail-rails from your Gemfile.
    from /Users/jflanagan/code/xray-rails/lib/xray/engine.rb:10:in `block in <class:Engine>'
```
