### PR TITLE
Added check that Xray injection is not being requested for Rails::InfoController#routes in Rails 4

### DIFF
--- a/app/views/_xray_bar.html.erb
+++ b/app/views/_xray_bar.html.erb
@@ -11,7 +11,6 @@
         </span>
       <% end %>
       <% if Xray.request_info[:view] && Xray.request_info[:controller][:name] != "Rails::InfoController" %>
-        <% binding.pry %>
         <% layout_path = lookup_context.find(Xray.request_info[:view][:layout]).identifier %>
         <span class="xray-bar-btn xray-bar-layout xray-icon-columns" data-path="<%= layout_path %>">
           <b></b>


### PR DESCRIPTION
Really enjoying using this plugin but encountered a problem in Rails 4 when the routes page was being requested - therefore I have added a check in the view file _xray_bar to not inject xray if the page being requested is the rails routes page.
