### PR TITLE
Gracefully handle nil for request_info[:controller]

### DIFF
--- a/app/views/_xray_bar.html.erb
+++ b/app/views/_xray_bar.html.erb
@@ -7,7 +7,7 @@
           <%= Xray.request_info[:controller][:name] %><span class="xray-bar-controller-action">#<%= Xray.request_info[:controller][:action] %></span>
         </span>
       <% end %>
-      <% if Xray.request_info[:view] && Xray.request_info[:controller][:name] != "Rails::InfoController" %>
+      <% if Xray.request_info[:view] && Xray.request_info.fetch(:controller, {})[:name] != "Rails::InfoController" %>
         <% layout_path = lookup_context.find(Xray.request_info[:view][:layout]).identifier %>
         <span class="xray-bar-btn xray-bar-layout xray-icon-columns" data-path="<%= layout_path %>">
           <b></b>


### PR DESCRIPTION
When previewing a mailer view template using the [mail_view](https://github.com/37signals/mail_view) gem (version 2.0.4), `Xray.request_info[:controller]` is nil. Use `fetch` to accommodate this scenario.
