### PR TITLE
fix undefined method 'variant' for nil:NilClass ActionController #render_to_text change API

### DIFF
--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -37,7 +37,7 @@ module Xray
         status, headers, response = @app.call(env)
 
         if html_headers?(status, headers) && body = response_body(response)
-          body = body.sub(/<body[^>]*>/) { "#{$~}\n#{xray_bar}" }
+          body = body.sub(/<body[^>]*>/) { "#{$~}\n#{xray_bar(response)}" }
           # Inject js script tags if assets are unbundled
           if Rails.application.config.assets.debug
             append_js!(body, 'jquery', 'xray')
@@ -61,8 +61,10 @@ module Xray
 
     private
 
-    def xray_bar
-      ActionController::Base.new.render_to_string(:partial => '/xray_bar').html_safe
+    def xray_bar(response)
+      ac = ActionController::Base.new
+      ac.request = response.request if response.respond_to?(:request)
+      ac.render_to_string(:partial => '/xray_bar').html_safe
     end
 
     # Appends the given `script_name` after the `after_script_name`.


### PR DESCRIPTION
I've tried to use xray-rails with rails 4.1 and it just blows up with `nil` no method error. It looks like we have to provide request object for ActionController::Base directly.

Here is the patch to fix it 

```
NoMethodError - undefined method `variant' for nil:NilClass:
  actionpack (4.1.0.rc1) lib/abstract_controller/rendering.rb:109:in `_normalize_render'
  actionpack (4.1.0.rc1) lib/abstract_controller/rendering.rb:42:in `render_to_string'
  actionpack (4.1.0.rc1) lib/action_controller/metal/rendering.rb:21:in `render_to_string'
  xray-rails (0.1.12) lib/xray/middleware.rb:65:in `xray_bar'
  xray-rails (0.1.12) lib/xray/middleware.rb:40:in `block in call'
  xray-rails (0.1.12) lib/xray/middleware.rb:40:in `call'
  warden (1.2.3) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.3) lib/warden/manager.rb:34:in `call'
  rack (1.5.2) lib/rack/etag.rb:23:in `call'
  rack (1.5.2) lib/rack/conditionalget.rb:25:in `call'
  rack (1.5.2) lib/rack/head.rb:11:in `call' 
```
