### PR TITLE
Provide option for Xray to be turned off in render options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Or for something more complex, use the `$file` placeholder.
 * When the overlay is shown, `xray.js` examines the file path information inserted during asset compilation.
 * Another middleware piggybacks the Rails server to respond to requests to open file paths with the user's desired editor.
 
+## Disabling Xray in particular templates
+
+Xray augments HTML templates and thus modifies them.  For some environments such as [Angular.js](http://angularjs.org/), this can cause Angular templates to stop working.  You can pass in the option `xray: false` to any render statements to ensure Xray does not augment that template.  Example:
+
+```ruby
+render 'show', xray: false
+```
+
 ## Contributing
 
 If you have an idea, open an issue and let's talk about it, or fork away and send a pull request.

--- a/lib/xray/engine.rb
+++ b/lib/xray/engine.rb
@@ -28,7 +28,9 @@ module Xray
         def render_with_xray(*args, &block)
           path = identifier
           source = render_without_xray(*args, &block)
-          if path =~ /\.(html|slim|haml)(\.|$)/ && !path.match(/\.(js|json)\./) && !path.include?('_xray_bar')
+          suitable_template = path =~ /\.(html|slim|haml)(\.|$)/ && !path.match(/\.(js|json)\./) && !path.include?('_xray_bar')
+          options = args.last.kind_of?(Hash) ? args.last : {}
+          if suitable_template && !(options.has_key?(:xray) && (options[:xray] == false))
             Xray.augment_template(source, path)
           else
             source

--- a/spec/xray/engine_spec.rb
+++ b/spec/xray/engine_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Xray::Engine do
+  context 'ActionView::Template monkeypatch #render' do
+    subject { ActionView::Template.new(nil, nil, nil, {}) }
+    let(:xray_enabled_render_args) { ['template', { example_option: true }] }
+    let(:xray_disabled_render_args) { ['template', { example_option: true, xray: false }] }
+    let(:render_result) { '<html>Example</html>' }
+    let(:plain_text_result) { 'Example' }
+    let(:augmented_render_result) { '<html>Example<script>Example XRAY</script></html>' }
+    let(:html_identifier) { 'template.html' }
+    let(:txt_identifier) { 'template.txt' }
+
+    it 'should render and augment valid HTML like files by default' do
+      subject.should_receive(:render_without_xray).with(*xray_enabled_render_args).and_return(render_result)
+      subject.should_receive(:identifier).and_return(html_identifier)
+      Xray.should_receive(:augment_template).with(render_result, html_identifier).and_return(augmented_render_result)
+      expect(subject.render(*xray_enabled_render_args)).to eql(augmented_render_result)
+    end
+
+    it 'should render but not augment HTML if :xray => false passed as an option' do
+      subject.should_receive(:render_without_xray).with(*xray_enabled_render_args).and_return(render_result)
+      subject.should_receive(:identifier).and_return(html_identifier)
+      Xray.should_receive(:augment_template).with(render_result, html_identifier).and_return(augmented_render_result)
+      expect(subject.render(*xray_enabled_render_args)).to eql(augmented_render_result)
+    end
+
+    it 'should render but not augment non HTML files' do
+      subject.should_receive(:render_without_xray).with(*xray_disabled_render_args).and_return(plain_text_result)
+      subject.should_receive(:identifier).and_return(txt_identifier)
+      Xray.should_not_receive(:augment_template)
+      expect(subject.render(*xray_disabled_render_args)).to eql(plain_text_result)
+    end
+  end
+end
+


### PR DESCRIPTION
AngularJS does not work when the templates are augmented so this commit allows the augmentation to be turned off with the option xray: false passed to the render statement.

Please note that when running your test suite currently, `spec/xray/middleware_spec.rb:69` fails every time.  This was failing before and after my tests were added.
