### PR TITLE
Do not render xray for CSS files

### DIFF
--- a/lib/xray/engine.rb
+++ b/lib/xray/engine.rb
@@ -31,7 +31,7 @@ module Xray
         def render_with_xray(*args, &block)
           path = identifier
           source = render_without_xray(*args, &block)
-          suitable_template = path =~ /\.(html|slim|haml)(\.|$)/ && !path.match(/\.(js|json)\./) && !path.include?('_xray_bar')
+          suitable_template = path =~ /\.(html|slim|haml)(\.|$)/ && !path.match(/\.(js|json|css)\./) && !path.include?('_xray_bar')
           options = args.last.kind_of?(Hash) ? args.last : {}
           if suitable_template && !(options.has_key?(:xray) && (options[:xray] == false))
             Xray.augment_template(source, path)


### PR DESCRIPTION
Example generated file (with SLIM):

``` css
<!--XRAY START 749 /Users/example_user/projects/example_project/app/views/customizations/show.css.slim-->
#header { background-color: #ceefff; }
#header .nav > li > a { color: #fb0; }
<!--XRAY END 749-->
```

In it's current state this blocks the first rule from being applied.
