### PR TITLE
Rails 4.2: Ensure xray works with asset digests enabled

### DIFF
--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -73,6 +73,7 @@ module Xray
       #   <script src="/assets/jquery.js"></script>
       #   <script src="/assets/jquery-min.js"></script>
       #   <script src="/assets/jquery.min.1.9.1.js"></script>
+      #   <script src="/assets/jquery.min.1.9.1-89255b9dbf3de2fbaa6754b3a00db431.js"></script>
       html.sub!(/<script[^>]+\/#{after_script_name}([-.]{1}[\d\.]+)?([-.]{1}min)?(-\h{32})?\.js[^>]+><\/script>/) do
         h = ActionController::Base.helpers
         "#{$~}\n" + h.javascript_include_tag(script_name)

--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -73,7 +73,7 @@ module Xray
       #   <script src="/assets/jquery.js"></script>
       #   <script src="/assets/jquery-min.js"></script>
       #   <script src="/assets/jquery.min.1.9.1.js"></script>
-      html.sub!(/<script[^>]+\/#{after_script_name}([-.]{1}[\d\.]+)?([-.]{1}min)?\.js[^>]+><\/script>/) do
+      html.sub!(/<script[^>]+\/#{after_script_name}([-.]{1}[\d\.]+)?([-.]{1}min)?(-\h{32})?\.js[^>]+><\/script>/) do
         h = ActionController::Base.helpers
         "#{$~}\n" + h.javascript_include_tag(script_name)
       end


### PR DESCRIPTION
In Rails 4.2, [asset digests are enabled in development](https://github.com/rails/rails/commit/f369bcf9a0dba0a945ca6fe53343c042f54c1fcf).

This causes xray to fail in Rails 4.2 apps, because it does not properly inject the necessary JS files.

This PR fixes the problem by tweaking the regex used to match JS files, in order to allow for asset digests. Specifically, it adds `(-\h{32})?`, which means "optionally allow the dash character followed by 32 hex digits".
