### PR TITLE
Add xray-backbone to precompile list

### DIFF
--- a/lib/xray/engine.rb
+++ b/lib/xray/engine.rb
@@ -11,7 +11,7 @@ module Xray
       app.middleware.use Xray::Middleware
 
       # Required by Rails 4.1
-      app.config.assets.precompile += %w(xray.js xray.css)
+      app.config.assets.precompile += %w(xray.js xray-backbone.js xray.css)
 
       # Register as a Sprockets processor to augment JS files, including
       # compiled coffeescript, with filepath information. See


### PR DESCRIPTION
This ensures that the xray-backbone.js file can be served by the default asset pipeline settings in the latest versions of Rails.

Addresses #53 
