### PR TITLE
Support sprockets 3

### DIFF
--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -74,7 +74,7 @@ module Xray
       #   <script src="/assets/jquery-min.js"></script>
       #   <script src="/assets/jquery.min.1.9.1.js"></script>
       #   <script src="/assets/jquery.min.1.9.1-89255b9dbf3de2fbaa6754b3a00db431.js"></script>
-      html.sub!(/<script[^>]+\/#{after_script_name}([-.]{1}[\d\.]+)?([-.]{1}min)?(-\h{32})?\.js[^>]+><\/script>/) do
+      html.sub!(/<script[^>]+\/#{after_script_name}([-.]{1}[\d\.]+)?([-.]{1}min)?(\.self)?(-\h{32,64})?\.js[^>]+><\/script>/) do
         h = ActionController::Base.helpers
         "#{$~}\n" + h.javascript_include_tag(script_name)
       end

--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -74,7 +74,17 @@ module Xray
       #   <script src="/assets/jquery-min.js"></script>
       #   <script src="/assets/jquery.min.1.9.1.js"></script>
       #   <script src="/assets/jquery.min.1.9.1-89255b9dbf3de2fbaa6754b3a00db431.js"></script>
-      html.sub!(/<script[^>]+\/#{after_script_name}([-.]{1}[\d\.]+)?([-.]{1}min)?(\.self)?(-\h{32,64})?\.js[^>]+><\/script>/) do
+      script_pattern = /
+        <script[^>]+
+        \/#{after_script_name} # Name of the script itself
+        ([-.]{1}[\d\.]+)?      # Optional version identifier (e.g. -1.9.1)
+        ([-.]{1}min)?          # Optional -min suffix
+        (\.self)?              # Sprockets 3 appends .self to the filename
+        (-\h{32,64})?          # Fingerprint varies based on Sprockets version
+        \.js                   # Must have .js extension
+        [^>]+><\/script>
+      /x
+      html.sub!(script_pattern) do
         h = ActionController::Base.helpers
         "#{$~}\n" + h.javascript_include_tag(script_name)
       end


### PR DESCRIPTION
As mentioned in #55, xray-rails doesn't work with Sprockets 3.

This is due to two changes to the format of the `<script>` elements introduced in Sprockets 3:
1. The fingerprint has increased from 32 to 64 characters.
2. Sprockets now appends `.self` to the filename.

For example, the jQuery script element generated by Sprockets 3 looks like this:

``` html
<script src="/assets/jquery.self-d03a5518f45df77341bdbe6201ba3bfa547ebba8ed64f0ea56bfa5f96ea7c074.js?body=1"></script>
```

…which breaks the regular expression that xray-rails uses to match the jQuery element.

This PR adds compatibility with Sprockets 3 by updating the regular expression to match the new script element format. I also reformatted the regexp to improve readability of the code.
