### PR TITLE
Add Rails 4.2.x compatibility

### DIFF
--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -44,6 +44,12 @@ module Xray
             append_js!(body, 'backbone', 'xray-backbone')
           end
           content_length = body.bytesize.to_s
+
+          # For rails v4.2.0+ compatibility
+          if defined?(ActionDispatch::Response::RackBody) && ActionDispatch::Response::RackBody === response
+            response = response.instance_variable_get(:@response)
+          end
+
           # Modifying the original response obj maintains compatibility with other middlewares
           if ActionDispatch::Response === response
             response.body = [body]


### PR DESCRIPTION
Using xray-rails and Rails 4.2.x, we cannot see any popup alerts or console.log for the bullet(https://github.com/flyerhzm/bullet)

This patch fixes the issues.