### PR TITLE
Add sprockets-rails 3.0.0 compatibility

### DIFF
--- a/lib/xray/engine.rb
+++ b/lib/xray/engine.rb
@@ -7,11 +7,14 @@ module Xray
   # xray.js and the xray bar into the app's response bodies.
   class Engine < ::Rails::Engine
     initializer "xray.initialize" do |app|
-      ensure_asset_pipeline_enabled! app
       app.middleware.use Xray::Middleware
 
       # Required by Rails 4.1
       app.config.assets.precompile += %w(xray.js xray-backbone.js xray.css)
+    end
+
+    config.after_initialize do |app|
+      ensure_asset_pipeline_enabled! app
 
       # Register as a Sprockets processor to augment JS files, including
       # compiled coffeescript, with filepath information. See


### PR DESCRIPTION
It seems that sprockets-rails 3.0.0 does not initialize the `app.assets` object until it runs its `after_initialize` block. This means that xray-rails must move its initialization process into `after_initialize` as well.

The exception is the `config.assets.precompile` modifications, which must be done earlier before that array gets frozen.

These changes fix the "asset pipeline is currently disabled" error when starting up a Rails app that uses sprockets-rails 3.0.0.

This fixes #61.

@brentd Could you give me some pointers on how to test this PR? I am having trouble getting `rspec` to run (maybe you could share your Gemfile.lock?). I've manually tested this patch using a Rails 4.2.5 app, but I'd like to make sure the test suite passes (and ideally test older versions of Rails and sprockets-rails as well).

_Edit: I got `rspec` working and the tests are passing._
