### PR TITLE
Allows automatic require when using jQuery2

### DIFF
--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -91,6 +91,7 @@ module Xray
       /
         <script[^>]+
         \/#{script_name}
+        (2)?                   # Optional 2 for jQuery2 format
         ([-.]{1}[\d\.]+)?      # Optional version identifier (e.g. -1.9.1)
         ([-.]{1}min)?          # Optional -min suffix
         (\.self)?              # Sprockets 3 appends .self to the filename

--- a/spec/xray/middleware_spec.rb
+++ b/spec/xray/middleware_spec.rb
@@ -34,6 +34,19 @@ describe Xray::Middleware, "in a middleware stack" do
       expect(response.body).to_not have_selector('#xray-bar')
       expect(response.body).to_not have_selector('script[src^="/assets/xray"]')
     end
+
+    it "does inject xray.js or the xray bar if jquery2 is found" do
+      response = mock_response 200, 'text/html', <<-HTML
+      <html>
+        <head>
+          <script src=\"/assets/jquery2.js\"></script>
+        </head>
+        <body></body>
+      </html>
+      HTML
+      expect(response.body).to have_selector('#xray-bar')
+      expect(response.body).to have_selector('script[src^="/assets/xray"]')
+    end
   end
 
   context "when the response does not contain <body>" do


### PR DESCRIPTION
I think we could adjust the Optional version identifier (e.g. -1.9.1) to make the dash optional instead [-.]{0,1}[\d\.]+)? but it has been a bit since I worked with RegEx that much.