### PR TITLE
Use $EDITOR by default instead of Sublime Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,18 @@ Backbone support via `xray-backbone` is optional.
 
 ## Configuration
 
-By default, Xray will open files with Sublime Text, looking for `/usr/local/bin/subl`.
+By default, Xray will check a few environment variables to determine
+which editor to open files in: `$GEM_EDITOR`, `$VISUAL`, then
+`$EDITOR` before falling back to `/usr/local/bin/subl`.
 
-You can configure this to be your editor of choice in Xray's UI, or create `~/.xrayconfig`, a YAML file.
-
-Example `.xrayconfig`:
+You can configure your editor of choice either by setting one of these
+variables, or in Xray's UI, or in an `~/.xrayconfig` YAML file:
 
 ```yaml
 :editor: '/usr/local/bin/mate'
 ```
 
-Or for something more complex, use the `$file` placeholder.
+For something more complex, use the `$file` placeholder.
 
 ```yaml
 :editor: "/usr/local/bin/tmux new-window 'vim $file'"

--- a/lib/xray/config.rb
+++ b/lib/xray/config.rb
@@ -8,7 +8,13 @@ module Xray
     attr_accessor :editor
 
     CONFIG_FILE = ".xrayconfig"
-    DEFAULT_EDITOR = '/usr/local/bin/subl'
+
+    def default_editor
+      ENV['GEM_EDITOR'] ||
+        ENV['VISUAL'] ||
+        ENV['EDITOR'] ||
+        '/usr/local/bin/subl'
+    end
 
     def editor
       load_config[:editor]
@@ -53,8 +59,7 @@ module Xray
     end
 
     def default_config
-      { editor: DEFAULT_EDITOR }
+      { editor: default_editor }
     end
-
   end
 end

--- a/spec/xray/config_spec.rb
+++ b/spec/xray/config_spec.rb
@@ -1,6 +1,36 @@
 require 'spec_helper'
 
 describe Xray::Config do
+  context 'default_editor' do
+    before do
+      Xray.config.stub(:local_config).and_return({})
+    end
+
+    it 'should default to /usr/local/bin/subl' do
+      ENV.stub(:[])
+      Xray.config.editor.should eq('/usr/local/bin/subl')
+    end
+
+    it 'should use $GEM_EDITOR over $VISUAL and $EDITOR' do
+      ENV['GEM_EDITOR'] = 'vim'
+      ENV['VISUAL'] = 'emacs'
+      ENV['EDITOR'] = 'emacs'
+      Xray.config.editor.should eq('vim')
+    end
+
+    it 'should use $VISUAL over $EDITOR' do
+      ENV['GEM_EDITOR'] = nil
+      ENV['VISUAL'] = 'vim'
+      ENV['EDITOR'] = 'emacs'
+      Xray.config.editor.should eq('vim')
+    end
+
+    it 'should use $HOME/.xrayconfig over env variables' do
+      ENV['GEM_EDITOR'] = 'vim'
+      Xray.config.stub(:local_config).and_return(editor: 'emacs')
+      Xray.config.editor.should eq('emacs')
+    end
+  end
 
   context ".config_file" do
     it "should use $HOME/.xrayconfig as default config file" do


### PR DESCRIPTION
The `$EDITOR` variable is a well-established convention, and people using Sublime probably have it set to `subl`, so I think this is probably a better default setting.