### PR TITLE
Add Rails 5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ lesser changes or bug fixes.
 ## [Unreleased][]
 
 * Your contribution here!
+* Added support for Rails 5.0.0.rc1.
+  [#70](https://github.com/brentd/xray-rails/pull/70)
 
 ## [0.1.19][] (2016-05-06)
 

--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -59,7 +59,7 @@ module Xray
           # Modifying the original response obj maintains compatibility with other middlewares
           if ActionDispatch::Response === response
             response.body = [body]
-            response.header['Content-Length'] = content_length
+            response.header['Content-Length'] = content_length unless response.try(:committed?)
             response.to_a
           else
             headers['Content-Length'] = content_length
@@ -78,8 +78,14 @@ module Xray
     end
 
     def render_xray_bar
-      ac = ActionController::Base.new
-      ac.render_to_string(:partial => '/xray_bar').html_safe
+      if ApplicationController.respond_to?(:render)
+        # Rails 5
+        ApplicationController.render(:partial => "/xray_bar").html_safe
+      else
+        # Rails <= 4.2
+        ac = ActionController::Base.new
+        ac.render_to_string(:partial => '/xray_bar').html_safe
+      end
     end
 
     # Matches:


### PR DESCRIPTION
Two changes were necessary to add support for Rails 5.
1. Rails 5 has a new rendering system that allows code such as xray's to render a view to a String from outside of a controller. This works using the new `ApplicationController.render` method. The old technique no longer works. To work without breaking compatibility with older Rails versions, we check to see if the new `render` method exists and use it if available; otherwise fall back to the previous technique.
2. Rails 5 uses streaming responses that are implicitly "committed" once the body of the response is read. Since xray must read the response in order to modify it (i.e. inject its JS), this causes the response to be considered committed, preventing changes to its headers. Hence we can no longer change the "Content-Length" header after modifying the body. We can still do so for older versions of Rails, but now we skip it if the response has the Rails 5  `committed?` flag.

These changes were tested with Rails 5.0.0.rc1.

Fixes #63.
