### PR TITLE
Fix Rails 3.2 compatibility by not using `try`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ lesser changes or bug fixes.
 ## [Unreleased][]
 
 * Your contribution here!
+* Fix a regression in 0.1.20 that broke Rails 3.2 apps
+  [#72](https://github.com/brentd/xray-rails/pull/72)
 
 ## [0.1.20][] (2016-05-18)
 

--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -59,7 +59,7 @@ module Xray
           # Modifying the original response obj maintains compatibility with other middlewares
           if ActionDispatch::Response === response
             response.body = [body]
-            response.header['Content-Length'] = content_length unless response.try(:committed?)
+            response.header['Content-Length'] = content_length unless committed?(response)
             response.to_a
           else
             headers['Content-Length'] = content_length
@@ -72,6 +72,10 @@ module Xray
     end
 
     private
+
+    def committed?(response)
+      response.respond_to?(:committed?) && response.committed?
+    end
 
     def inject_xray_bar!(html)
       html.sub!(/<body[^>]*>/) { "#{$~}\n#{render_xray_bar}" }


### PR DESCRIPTION
The ActiveSupport `try` method works differently in different versions of Rails. In some versions it checks `respond_to?`; others do not. It is safer (and more compatible) to explicitly use `respond_to?` instead.

Fixes #71 
