### PR TITLE
Handle empty templates

### DIFF
--- a/lib/xray/engine.rb
+++ b/lib/xray/engine.rb
@@ -43,7 +43,7 @@ module Xray
 
           options = args.last.kind_of?(Hash) ? args.last : {}
 
-          if suitable_template && !(options.has_key?(:xray) && (options[:xray] == false))
+          if source && suitable_template && !(options.has_key?(:xray) && (options[:xray] == false))
             Xray.augment_template(source, path)
           else
             source


### PR DESCRIPTION
If the template returns without rendering anything, `Xray.augment_template` should not be called.

The scenario might be a conditional `return` statement in a partial, to avoid it being rendered in some cases.

Alternatively, `Xray.augment_template` could return immediately if the input source is nil?