### PR TITLE
Remove alias_method_chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ lesser changes or bug fixes.
 ## [Unreleased][]
 
 * Your contribution here!
+* Remove `alias_method_chain` and make xray-rails compatible with Rails 5.1.
 
 ## [0.2.0][] (2016-09-23)
 

--- a/lib/xray-rails.rb
+++ b/lib/xray-rails.rb
@@ -1,6 +1,7 @@
 require "json"
 require "active_support/all"
 require_relative "xray/version"
+require_relative "xray/aliasing"
 require_relative "xray/config"
 require_relative "xray/middleware"
 

--- a/lib/xray/aliasing.rb
+++ b/lib/xray/aliasing.rb
@@ -1,0 +1,38 @@
+module Xray
+  # This module implements the old ActiveSupport alias_method_chain feature
+  # with a new name, and without the deprecation warnings. In ActiveSupport 5+,
+  # this style of patching was deprecated in favor of Module.prepend. But
+  # Module.prepend is not present in Ruby 1.9, which we would still like to
+  # support. So we continue to use of alias_method_chain, albeit with a
+  # different name to avoid collisions.
+  #
+  # TODO: remove this and drop support for Ruby 1.9.
+  #
+  module Aliasing
+    # This code is copied and pasted from ActiveSupport, but with :xray
+    # hardcoded as the feature name, and with the deprecation warning removed.
+    def xray_method_alias(target)
+      feature = :xray
+
+      # Strip out punctuation on predicates, bang or writer methods since
+      # e.g. target?_without_feature is not a valid method name.
+      aliased_target, punctuation = target.to_s.sub(/([?!=])$/, ''), $1
+      yield(aliased_target, punctuation) if block_given?
+
+      with_method = "#{aliased_target}_with_#{feature}#{punctuation}"
+      without_method = "#{aliased_target}_without_#{feature}#{punctuation}"
+
+      alias_method without_method, target
+      alias_method target, with_method
+
+      case
+      when public_method_defined?(without_method)
+        public target
+      when protected_method_defined?(without_method)
+        protected target
+      when private_method_defined?(without_method)
+        private target
+      end
+    end
+  end
+end

--- a/lib/xray/engine.rb
+++ b/lib/xray/engine.rb
@@ -19,6 +19,8 @@ module Xray
       # Monkey patch ActionView::Template to augment server-side templates
       # with filepath information. See `Xray.augment_template` for details.
       ActionView::Template.class_eval do
+        extend Xray::Aliasing
+
         def render_with_xray(*args, &block)
           path = identifier
           view = args.first
@@ -37,7 +39,7 @@ module Xray
             source
           end
         end
-        alias_method_chain :render, :xray
+        xray_method_alias :render
       end
 
       # Sprockets preprocessor interface which supports all versions of Sprockets.


### PR DESCRIPTION
This commit removes `alias_method_chain` and replaces it with somewhat of a hack. We cannot right out switch to `Module.prepend` without sacrificing Ruby 1.9 compatibility and rewriting our specs.

This ensures we can support Rails 5.1, which no longer has `alias_method_chain` at all.