### PR TITLE
use Xray config for change the key code trigger

### DIFF
--- a/app/assets/javascripts/xray.js
+++ b/app/assets/javascripts/xray.js
@@ -12,7 +12,9 @@
   }
 
   MAX_ZINDEX = 2147483647;
-
+  Xray.config = {
+    keyCodeTrigger: 88 // 'x'
+  }
   Xray.init = (function() {
     var is_mac;
     if (Xray.initialized) {
@@ -21,7 +23,7 @@
     Xray.initialized = true;
     is_mac = navigator.platform.toUpperCase().indexOf('MAC') !== -1;
     $(document).keydown(function(e) {
-      if ((is_mac && e.metaKey || !is_mac && e.ctrlKey) && e.shiftKey && e.keyCode === 88) {
+      if ((is_mac && e.metaKey || !is_mac && e.ctrlKey) && e.shiftKey && e.keyCode === Xray.config.keyCodeTrigger) {
         if (Xray.isShowing) {
           Xray.hide();
         } else {

--- a/app/assets/javascripts/xray.js.coffee
+++ b/app/assets/javascripts/xray.js.coffee
@@ -3,7 +3,9 @@ return unless $ = window.jQuery
 
 # Max CSS z-index. The overlay and xray bar use this.
 MAX_ZINDEX = 2147483647
-
+Xray.config = {
+  keyCodeTrigger: 88 # 'x'
+}
 # Initialize Xray. Called immediately, but some setup is deferred until DOM ready.
 Xray.init = do ->
   return if Xray.initialized
@@ -13,8 +15,8 @@ Xray.init = do ->
 
   # Register keyboard shortcuts
   $(document).keydown (e) ->
-    # cmd+shift+x on Mac, ctrl+shift+x on other platforms
-    if (is_mac and e.metaKey or !is_mac and e.ctrlKey) and e.shiftKey and e.keyCode is 88
+    # default cmd+shift+x on Mac, ctrl+shift+x on other platforms
+    if (is_mac and e.metaKey or !is_mac and e.ctrlKey) and e.shiftKey and e.keyCode is Xray.config.keyCodeTrigger
       if Xray.isShowing then Xray.hide() else Xray.show()
     if Xray.isShowing and e.keyCode is 27 # esc
       Xray.hide()


### PR DESCRIPTION
Hi @brentd 

this gem it's very useful, i think that would be better change the key code trigger, because some browser extensions or other javascript not works well with the cmd+shift+x 

I propose change the 'x' key for another like this
```javascript
Xray.config.keyCodeTrigger = 76 // l
```
