### PR TITLE
[Enhance] Deprecated RSpec Syntax

### DIFF
--- a/spec/xray/augmentation_spec.rb
+++ b/spec/xray/augmentation_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Xray.augment_template" do
   it "wraps HTML source with comments containing the path" do
-    Xray.stub(next_id: 1)
+    allow(Xray).to receive(:next_id).and_return(1)
     source = <<-END.unindent
       <div class="container">
       </div>

--- a/spec/xray/command_spec.rb
+++ b/spec/xray/command_spec.rb
@@ -4,13 +4,13 @@ describe 'Xray.open_file' do
   let(:file) { '/path/to/file' }
 
   it "uses the configured editor" do
-    Xray.config.stub(editor: 'cool_editor')
+    allow(Xray.config).to receive(:editor).and_return('cool_editor')
     Open3.should_receive(:capture3).with("cool_editor \"#{file}\"")
     Xray.open_file(file)
   end
 
   it "replace $file in the editor command with the filename" do
-    Xray.config.stub(editor: 'cool_editor --open "$file"')
+    allow(Xray.config).to receive(:editor).and_return('cool_editor --open "$file"')
     Open3.should_receive(:capture3).with("cool_editor --open \"#{file}\"")
     Xray.open_file(file)
   end

--- a/spec/xray/config_spec.rb
+++ b/spec/xray/config_spec.rb
@@ -8,40 +8,40 @@ describe Xray::Config do
 
     it 'should default to /usr/local/bin/subl' do
       ENV.stub(:[])
-      Xray.config.editor.should eq('/usr/local/bin/subl')
+      expect(Xray.config.editor).to eq('/usr/local/bin/subl')
     end
 
     it 'should use $GEM_EDITOR over $VISUAL and $EDITOR' do
       ENV['GEM_EDITOR'] = 'vim'
       ENV['VISUAL'] = 'emacs'
       ENV['EDITOR'] = 'emacs'
-      Xray.config.editor.should eq('vim')
+      expect(Xray.config.editor).to eq('vim')
     end
 
     it 'should use $VISUAL over $EDITOR' do
       ENV['GEM_EDITOR'] = nil
       ENV['VISUAL'] = 'vim'
       ENV['EDITOR'] = 'emacs'
-      Xray.config.editor.should eq('vim')
+      expect(Xray.config.editor).to eq('vim')
     end
 
     it 'should use $HOME/.xrayconfig over env variables' do
       ENV['GEM_EDITOR'] = 'vim'
       Xray.config.stub(:local_config).and_return(editor: 'emacs')
-      Xray.config.editor.should eq('emacs')
+      expect(Xray.config.editor).to eq('emacs')
     end
   end
 
   context ".config_file" do
     it "should use $HOME/.xrayconfig as default config file" do
       Dir.stub(:home).and_return('/home')
-      Xray.config.config_file.should eq('/home/.xrayconfig')
+      expect(Xray.config.config_file).to eq('/home/.xrayconfig')
     end
 
     it "should use $PROJECT/.xrayconfig if it exists" do
       File.stub(:exists?).and_return(true)
       Dir.stub(:pwd).and_return('/project')
-      Xray.config.config_file.should eq("/project/.xrayconfig")
+      expect(Xray.config.config_file).to eq("/project/.xrayconfig")
     end
   end
 end

--- a/spec/xray/xray_bar_spec.rb
+++ b/spec/xray/xray_bar_spec.rb
@@ -4,14 +4,14 @@ describe "Xray Bar" do
   before { visit '/' }
 
   it "includes the controller and action" do
-    find('#xray-bar').should have_text('ApplicationController#root')
+    expect(find('#xray-bar')).to have_text('ApplicationController#root')
   end
 
   it "includes the layout used" do
-    find('#xray-bar').should have_text('application.html.erb')
+    expect(find('#xray-bar')).to have_text('application.html.erb')
   end
 
   it "includes the view rendered" do
-    find('#xray-bar').should have_text('root.html.erb')
+    expect(find('#xray-bar')).to have_text('root.html.erb')
   end
 end


### PR DESCRIPTION
### Objective

Since I've encountered something like this in new RSpec rails version

```bash
Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/berniechiu/development/ruby_projects/xray-rails/spec/xray/xray_bar_spec.rb:7:in `block (2 levels) in <top (required)>'.

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/berniechiu/development/ruby_projects/xray-rails/spec/xray/augmentation_spec.rb:5:in `block (2 levels) in <top (required)>'.
```

I wonder if we can remove it in case it's deprecated some day, thanks~

### Feature

Update the newer syntax to keep in-line with current RSpec