### PR TITLE
Switch to un-prefixed radial-gradient syntax

### DIFF
--- a/app/assets/stylesheets/xray.css
+++ b/app/assets/stylesheets/xray.css
@@ -38,7 +38,7 @@
 #xray-overlay {
   position: fixed; left: 0; top: 0; bottom: 0; right: 0;
   background: rgba(0,0,0,0.7);
-  background: -webkit-radial-gradient(center, ellipse cover, rgba(0,0,0,0.4) 10%, rgba(0,0,0,0.8) 100%);
+  background: radial-gradient(center, ellipse farthest-corner, rgba(0,0,0,0.4) 10%, rgba(0,0,0,0.8) 100%);
   z-index: 9000;
 }
 


### PR DESCRIPTION
`radial-gradient` is now supported by all current browsers:

https://caniuse.com/#search=radial-gradient

Also, the `cover` keyword has been deprecated in favor of `farthest-corner`. This fixes the following autoprefixer warning:

```
autoprefixer: xray-rails-0.3.1/app/assets/stylesheets/xray.css:42:3:
Gradient has outdated direction syntax. Replace `cover` to `farthest-corner`.
```