### PR TITLE
Pin bundler to avoid Travis failures for old rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ matrix:
       env: RAILS_VERSION="~> 5.0.0"
     - rvm: 2.4.0
       env: RAILS_VERSION="~> 5.0.0"
-before_install: gem update bundler
+before_install: gem install bundler -v "~> 1.17" --no-document


### PR DESCRIPTION
The Travis config had a `gem update bundler` step. The newest version of Bundler (2.0) has dropped support for EOL versions of Ruby, so this step would fail in Travis for old version of Ruby.

Fix by changing this step so that we always install Bundler 1.x, which supports the older versions of Ruby.