### PR TITLE
Add config option to defer loading of Xray script

### DIFF
--- a/lib/xray/config.rb
+++ b/lib/xray/config.rb
@@ -27,6 +27,10 @@ module Xray
       end
     end
 
+    def defer_script
+      local_config[:defer_script] || false
+    end
+
     def to_yaml
       {editor: editor}.to_yaml
     end

--- a/lib/xray/middleware.rb
+++ b/lib/xray/middleware.rb
@@ -113,7 +113,7 @@ module Xray
     # Appends the given `script_name` after the `after_script_name`.
     def append_js!(html, after_script_name, script_name)
       html.sub!(script_matcher(after_script_name)) do
-        "#{$~}\n" + helper.javascript_include_tag(script_name)
+        "#{$~}\n" + helper.javascript_include_tag(script_name, defer: Xray.config.defer_script)
       end
     end
 


### PR DESCRIPTION
When loading of jQuery is deferred, the Javascript `Xray` script loads ahead of this and loads a blank object.

This is a stripped down approach to allow defer loading the script, via a config option.