### PR TITLE
adopt Apple spelling conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Xray-rails
 
 The dev tools available to web developers in modern browsers are great. Many of us can't remember what life was like before "Inspect Element". But what we see in the compiled output sent to our browser is often the wrong level of detail - what about visualizing the higher level components of your UI? Controllers, view templates, partials, JS templates, etc.
 
-Xray is the missing link between the browser and your app code. Press **cmd+shift+x** (Mac) or **ctrl+shift+x** to reveal an overlay of the files that rendered your UI, and click anything to open the file in your editor.
+Xray is the missing link between the browser and your app code. Press **command+shift+x** (Mac) or **ctrl+shift+x** to reveal an overlay of the files that rendered your UI, and click anything to open the file in your editor.
 
 ![Screenshot](example/screenshot.png)
 
@@ -39,7 +39,7 @@ Then bundle and delete your cached assets:
 $ bundle && rm -rf tmp/cache/assets
 ```
 
-Restart your app, visit it in your browser, and press **cmd+shift+x** (Mac) or **ctrl+shift+x** to reveal the overlay.
+Restart your app, visit it in your browser, and press **command+shift+x** (Mac) or **ctrl+shift+x** to reveal the overlay.
 
 #### Note about `config.assets.debug`
 


### PR DESCRIPTION
Apple keyboards conventionally spell out the word "command" rather than abbreviating it the way Windows keyboards abbreviate 'control' as 'ctrl'.